### PR TITLE
Convert labels into comments

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,12 @@
 # Description
 
-Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
+<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
 
 Closes #[REPLACE WITH ISSUE NUMBER]
 
 ## Type of change
 
-Please delete options that are not relevant.
+<!-- Please delete options that are not relevant. -->
 
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
@@ -15,19 +15,20 @@ Please delete options that are not relevant.
 
 # How Has This Been Tested?
 
-Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
+<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
 
 - [ ] Test A
 - [ ] Test B
 
 **Test Configuration**:
 
-Please remove sections that are not relevant.
-* Node.js version:
-* Python version:
-* Desktop/Mobile:
-* OS:
-* Browser:
+<!-- Please remove sections that are not relevant. -->
+
+- Node.js version:
+- Python version:
+- Desktop/Mobile:
+- OS:
+- Browser:
 
 # Checklist:
 


### PR DESCRIPTION
# Description

Convert labels into comments so that if a developer forgets to remove the placeholder text instructions, we don't keep seeing the same duplicate text come out in PRs.

Closes #[REPLACE WITH ISSUE NUMBER]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

🙏

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
